### PR TITLE
Bump websocket-extensions gem to non vulnerable version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
       railties (>= 4.2)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.3.0)
@@ -205,7 +205,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
-  puma (~> 4.1)
+  puma (~> 4.3.5)
   rails (~> 6.0.2, >= 6.0.3.1)
   sass-rails (>= 6)
   selenium-webdriver


### PR DESCRIPTION
 Bump gem from 0.1.0 to 0.1.5 in order to fix possible vulnerabilities